### PR TITLE
Added Uri.UnescapeDataString(parameters[i + 1])

### DIFF
--- a/Nancy.OData.Test/Nancy.OData.Test.csproj
+++ b/Nancy.OData.Test/Nancy.OData.Test.csproj
@@ -35,8 +35,9 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Linq2Rest">
-      <HintPath>..\packages\Linq2Rest.2.0.0.0\lib\Net40\Linq2Rest.dll</HintPath>
+    <Reference Include="Linq2Rest, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Linq2Rest.2.1.0.0\lib\Net40\Linq2Rest.dll</HintPath>
     </Reference>
     <Reference Include="Nancy">
       <HintPath>..\packages\Nancy.0.10.0\lib\net40\Nancy.dll</HintPath>

--- a/Nancy.OData.Test/TestModule.cs
+++ b/Nancy.OData.Test/TestModule.cs
@@ -10,9 +10,9 @@ namespace Nancy.OData.Test
             Get["/Test/{stuff}/"] = x =>
             {
                 return Response.AsOData(new List<Stuff> {
-                new Stuff {             Name = "one" }, 
-                     new Stuff { Name = "two" }, 
-                        new Stuff { Name = "Three"}
+                new Stuff {Id = 1, Name = "one" }, 
+                     new Stuff {Id = 2, Name = "two" }, 
+                        new Stuff {Id = 3, Name = "Three"}
                 });
             };
         }
@@ -20,6 +20,7 @@ namespace Nancy.OData.Test
 
     public class Stuff
     {
+        public int Id { get; set; }
         public string Name { get; set; }
     }
 }

--- a/Nancy.OData.Test/packages.config
+++ b/Nancy.OData.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Linq2Rest" version="2.0.0.0" />
+  <package id="Linq2Rest" version="2.1.0.0" />
   <package id="Nancy" version="0.10.0" />
   <package id="Nancy.Hosting.Self" version="0.10.0" />
 </packages>

--- a/Nancy.OData.sln
+++ b/Nancy.OData.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 11
+# Visual Web Developer Express 11
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nancy.OData", "Nancy.OData\Nancy.OData.csproj", "{630AB0D8-214B-4622-A8BD-9FD96C8B934D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nancy.OData.Test", "Nancy.OData.Test\Nancy.OData.Test.csproj", "{A30B6612-C858-4D65-A730-BEB09AEF42D2}"

--- a/Nancy.OData/ODataExtensions.cs
+++ b/Nancy.OData/ODataExtensions.cs
@@ -31,7 +31,7 @@ namespace Nancy.OData
             }
             for (int i = 0; i < parameters.Length; i += 2)
             {
-                nv.Add(parameters[i], parameters[i + 1]);
+                nv.Add(parameters[i], Uri.UnescapeDataString(parameters[i + 1]));
             }
             context.Items.Add(ODATA_URI_KEY, nv);
             return nv;


### PR DESCRIPTION
The $filter odata query options didn't work because if the value is not Unescaped linq2rest try to filter

http://localhost:5150/Test/a?$filter=Name%20eq%20%22two%22

instead of

http://localhost:5150/Test/a?$filter=Name eq "two"

thanks for the extension, you should create a nuget package.....
